### PR TITLE
make the KibanaHost configurable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,4 +1,9 @@
 class kibana::config {
+
+  include 'kibana'
+
+  $kibana_host = $kibana::kibana_host
+
   file { '/opt/kibana/KibanaConfig.rb':
     ensure  => present,
     content => template('kibana/opt/kibana/KibanaConfig.rb.erb')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,6 @@
 class kibana(
   $manage_ruby = false,
+  $kibana_host = 'localhost',
 ){
   validate_bool($manage_ruby)
   class { 'kibana::install': } ->

--- a/templates/opt/kibana/KibanaConfig.rb.erb
+++ b/templates/opt/kibana/KibanaConfig.rb.erb
@@ -13,7 +13,7 @@ module KibanaConfig
 
   # The adress ip Kibana should listen on. Comment out or set to
   # 0.0.0.0 to listen on all interfaces.
-  # KibanaHost = '127.0.0.1'
+  KibanaHost = '<%= @kibana_host %>'
 
   # Below is an example showing how to configure the same variables
   # using environment variables, which can be set in an init script


### PR DESCRIPTION
This is useful when running behind a proxy that's NOT on the same host,
as well as when running in a development environment, where it's
"enough" to access Kibana directly.
